### PR TITLE
 [FIX] : vaildation 부분 수정 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -6,11 +6,10 @@ plugins {
 }
 
 sentry {
-    includeSourceContext = true
-
+    authToken = System.getProperty("SENTRY_AUTH_TOKEN") ?: ""
     org = "dajava"
     projectName = "java-spring-boot"
-    authToken = System.getenv("SENTRY_AUTH_TOKEN")
+    includeSourceContext = true
 }
 
 group = 'com.dajava'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -6,10 +6,11 @@ plugins {
 }
 
 sentry {
-    authToken = System.getProperty("SENTRY_AUTH_TOKEN") ?: ""
+    includeSourceContext = true
+
     org = "dajava"
     projectName = "java-spring-boot"
-    includeSourceContext = true
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }
 
 group = 'com.dajava'
@@ -32,7 +33,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework:spring-test'

--- a/backend/src/main/java/com/dajava/backend/domain/event/controller/EventLogController.java
+++ b/backend/src/main/java/com/dajava/backend/domain/event/controller/EventLogController.java
@@ -16,6 +16,7 @@ import com.dajava.backend.domain.event.validater.EventValidation;
 import com.dajava.backend.domain.event.validater.EventValidator;
 import com.dajava.backend.global.log.Loggable;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/dajava/backend/domain/event/controller/EventLogTestController.java
+++ b/backend/src/main/java/com/dajava/backend/domain/event/controller/EventLogTestController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dajava.backend.domain.event.es.scheduler.vaildation.EsAbusingCheckScheduler;
 import com.dajava.backend.domain.event.es.scheduler.vaildation.EsEventCleanUpScheduler;
 import com.dajava.backend.domain.event.es.scheduler.vaildation.EsEventValidateScheduler;
 
@@ -19,6 +20,7 @@ public class EventLogTestController {
 
 	private final EsEventValidateScheduler esEventValidateScheduler;
 	private final EsEventCleanUpScheduler esEventCleanUpScheduler;
+	private final EsAbusingCheckScheduler esAbusingCheckScheduler;
 
 	@Operation(summary = "검증 스케줄러 강제 푸쉬", description = "검증 스케줄러를 강제로 푸쉬합니다.")
 	@GetMapping("/test/push/validateScheduler")
@@ -34,5 +36,12 @@ public class EventLogTestController {
 	public String removeLog() {
 		esEventCleanUpScheduler.deleteOldEventDocuments();
 		return "click, move, scroll 로그 이벤트 삭제 완료";
+	}
+
+	@GetMapping("/test/abusing")
+	@ResponseStatus(HttpStatus.OK)
+	public String abusingLog() {
+		esAbusingCheckScheduler.runScheduledAbusingCheck();
+		return "어뷰징 스케줄러 실행 완료";
 	}
 }

--- a/backend/src/main/java/com/dajava/backend/domain/event/dto/PointerClickEventRequest.java
+++ b/backend/src/main/java/com/dajava/backend/domain/event/dto/PointerClickEventRequest.java
@@ -3,6 +3,7 @@ package com.dajava.backend.domain.event.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,34 +32,34 @@ public class PointerClickEventRequest {
 	@Schema(description = "행동 솔루션 신청시 생성된 UUID 식별자", example = "a07cb1fc-e5db-4578-89a6-34d7a31f9389", requiredMode = Schema.RequiredMode.REQUIRED)
 	private String memberSerialNumber;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "로그 데이터의 생성 시각", example = "1711963200000", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Long timestamp;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 브라우저 창의 가로 길이", example = "1280", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer browserWidth;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "클릭시 X 좌표값", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer clientX;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "클릭시 Y 좌표값", example = "500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer clientY;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 화면의 스크롤 상단 Y 좌표", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer scrollY;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "전체 페이지의 세로 길이", example = "1500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer scrollHeight;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 브라우저 창의 세로 길이", example = "500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer viewportHeight;
 

--- a/backend/src/main/java/com/dajava/backend/domain/event/dto/PointerMoveEventRequest.java
+++ b/backend/src/main/java/com/dajava/backend/domain/event/dto/PointerMoveEventRequest.java
@@ -37,29 +37,29 @@ public class PointerMoveEventRequest {
 	private Long timestamp;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 브라우저 창의 가로 길이", example = "1280", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer browserWidth;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "이동시 X 좌표값", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer clientX;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "이동시 Y 좌표값", example = "500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer clientY;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 화면의 스크롤 상단 Y 좌표", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer scrollY;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "전체 페이지의 세로 길이", example = "1500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer scrollHeight;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 브라우저 창의 세로 길이", example = "500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer viewportHeight;
 

--- a/backend/src/main/java/com/dajava/backend/domain/event/dto/PointerScrollEventRequest.java
+++ b/backend/src/main/java/com/dajava/backend/domain/event/dto/PointerScrollEventRequest.java
@@ -3,6 +3,7 @@ package com.dajava.backend.domain.event.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,26 +32,26 @@ public class PointerScrollEventRequest {
 	@Schema(description = "행동 솔루션 신청시 생성된 UUID 식별자", example = "a07cb1fc-e5db-4578-89a6-34d7a31f9389", requiredMode = Schema.RequiredMode.REQUIRED)
 	private String memberSerialNumber;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "로그 데이터의 생성 시각", example = "1711963200000", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Long timestamp;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 브라우저 창의 가로 길이", example = "1280", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer browserWidth;
 
-	@NotBlank
+	@NotNull
 	@Schema(description = "스크롤시 화면의 스크롤 상단 Y 좌표", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer scrollY;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "전체 페이지의 세로 길이", example = "1500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer scrollHeight;
 
 	@Min(1)
-	@NotBlank
+	@NotNull
 	@Schema(description = "현재 브라우저 창의 세로 길이", example = "500", requiredMode = Schema.RequiredMode.REQUIRED)
 	private Integer viewportHeight;
 

--- a/backend/src/main/java/com/dajava/backend/domain/event/es/scheduler/vaildation/htmlparser/state/TagOpenState.java
+++ b/backend/src/main/java/com/dajava/backend/domain/event/es/scheduler/vaildation/htmlparser/state/TagOpenState.java
@@ -9,6 +9,7 @@ public class TagOpenState implements ParserState {
 		context.match("<");
 		String tagName = context.readUntil(' ', '>', '/');
 
+
 		HtmlNode node = new HtmlNode();
 
 		// ✅ 현재 부모 노드에 자식으로 추가

--- a/backend/src/main/java/com/dajava/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/com/dajava/backend/global/config/CorsConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@Configuration
+//@Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
 	@Bean


### PR DESCRIPTION
## 📝 Part

- [x] BE
- [ ] FE
- [ ] Infra
- [ ] Docs
- [ ] Test

<br/>

## 🔎 작업 내용

Integer 같이 String 이 아닌데 NOTBLANK 어노테이션이 붙혀있던 DTO 속성 수정
### timestamp vaildation 관련 트러블 슈팅
이벤트 로그 DTO를 받아 각 속성에 대해 vaildation을 수행할 때 
timestamp 경우 DTO 타임스탬프 값과 long now = Instant.now().toEpochMilli();와 비교할 때 자바에선 메인보드의 RTC(Real-Time Clock) 또는 OS의 시스템 시계 값을 토대로 now 값을 반환 받아 DTO timestamp와 비교하는데 반환 받은 now 값이  작업 표시줄(Taskbar) 시계 시간과 일치하지 않을 수 있습니다.
작업 표시줄 시계는 1차적으로 RTC와 OS 시스템 시간값을 받고 NTP(Network Time Protocol) 서버와 주기적으로 동기화 (time.windows.com 등)해서 시계 데이터를 설정하는데 RTC 값과 NTP값이 괴리가 있는 경우 RTC 값을 수정하지 않고 NTP 서버 데이터를 채택해 시간을 보여주기 때문에  메인보드, OS의 시스템 시간이 실제 시간과 동기화 되 있지 않은 경우가 존재할 수 있습니다.

만약 로그 이벤트 vaildation 코드를 적용시켜 이벤트 로그 데이터를 전송할 때 timestamp 관련해서 vaildation 예외를 반환하는 경우 파워쉘에서 w32tm /query /status 명령어와 Get-Date 명령어로 RTC와 OS 시스템 시계 값을 확인해 현재 시간과 일치하는지 확인해보시길 바랍니다.

